### PR TITLE
Add documentation for "search" command

### DIFF
--- a/src/factoids.coffee
+++ b/src/factoids.coffee
@@ -18,6 +18,7 @@
 #   hubot remember <factoid> - remember a factoid
 #   hubot drop <factoid> - permanently forget a factoid
 #   hubot factoids - get a link to the raw factoid data
+#   hubot search <substring> - list factoids which match (by factoid key or result)
 #   !<factoid> - play back a factoid
 #
 # Author:


### PR DESCRIPTION
First thing my team members asked for, "is there search". It was there but not in the docs. Fixed!